### PR TITLE
Remove mention of FBX imporing in modelscript

### DIFF
--- a/Docs/Modelscript.md
+++ b/Docs/Modelscript.md
@@ -132,7 +132,7 @@ As an example though, this would rotate an object around the Z axis:
 # Importing models
 
 In a modelscript, you can also import models and object3ds from external files. The `type`
-must be one of `obj`, `fbx`, or `gltf`, if absent it will be guessed from the extension.
+must be one of `obj` or `gltf`, if absent it will be guessed from the extension.
 
 ```xml
 <?xml version="1.0" ?>


### PR DESCRIPTION
Was looking through the modelscript docs and read that `<import>` could import .fbx files, after trying and failing to do so I realised it had been removed and was just a doc error lol