### PR TITLE
(Hopefully) Fix Win11 Compatibility

### DIFF
--- a/PD2ModelParser/PD2ModelParser.csproj
+++ b/PD2ModelParser/PD2ModelParser.csproj
@@ -2,10 +2,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.WindowsDesktop.App" />


### PR DESCRIPTION
Should fix issues with the `System.Windows.Forms` DLL not loading on Windows 11 according to issue #24, this doesn't seem to revert linux functionality (in my limited testing of "does it compile?")